### PR TITLE
CCTRI - 1655 Manage authentication errors in SecurityTrails

### DIFF
--- a/api/client.py
+++ b/api/client.py
@@ -167,7 +167,9 @@ class SecurityTrailsClient:
 
         # catch wrong API key
         if response.status_code == HTTPStatus.FORBIDDEN:
-            raise AuthorizationError(response.text)
+            raise AuthorizationError(
+                response.json().get('message') or response.text
+            )
 
         if response.ok:
             return data_extractor(response)

--- a/api/client.py
+++ b/api/client.py
@@ -167,7 +167,7 @@ class SecurityTrailsClient:
 
         # catch wrong API key
         if response.status_code == HTTPStatus.FORBIDDEN:
-            raise AuthorizationError('Invalid API key')
+            raise AuthorizationError(response.text)
 
         if response.ok:
             return data_extractor(response)

--- a/api/client.py
+++ b/api/client.py
@@ -10,7 +10,8 @@ from requests.exceptions import SSLError
 from api.errors import (
     CriticalSecurityTrailsResponseError,
     UnprocessedPagesWarning,
-    SecurityTrailsSSLError
+    SecurityTrailsSSLError,
+    AuthorizationError
 )
 from api.utils import join_url, add_error
 
@@ -163,6 +164,11 @@ class SecurityTrailsClient:
             )
         except SSLError as error:
             raise SecurityTrailsSSLError(error)
+
+        # catch wrong API key
+        if response.text == \
+                '{"message":"Invalid authentication credentials"}\n':
+            raise AuthorizationError('Invalid API key')
 
         if response.ok:
             return data_extractor(response)

--- a/api/client.py
+++ b/api/client.py
@@ -166,8 +166,7 @@ class SecurityTrailsClient:
             raise SecurityTrailsSSLError(error)
 
         # catch wrong API key
-        if response.text == \
-                '{"message":"Invalid authentication credentials"}\n':
+        if response.status_code == HTTPStatus.FORBIDDEN:
             raise AuthorizationError('Invalid API key')
 
         if response.ok:

--- a/api/errors.py
+++ b/api/errors.py
@@ -7,6 +7,7 @@ TOO_MANY_REQUESTS = 'too many requests'
 UNAUTHORIZED = 'unauthorized'
 NOT_FOUND = 'not found'
 UNAVAILABLE = 'unavailable'
+AUTH_ERROR = 'authorization error'
 
 
 class TRFormattedError(Exception):
@@ -23,11 +24,11 @@ class TRFormattedError(Exception):
                 'message': self.message}
 
 
-class InvalidJWTError(TRFormattedError):
-    def __init__(self):
+class AuthorizationError(TRFormattedError):
+    def __init__(self, message):
         super().__init__(
-            PERMISSION_DENIED,
-            'Invalid Authorization Bearer JWT.'
+            AUTH_ERROR,
+            f'Authorization failed: {message}'
         )
 
 

--- a/api/utils.py
+++ b/api/utils.py
@@ -34,7 +34,9 @@ def get_jwt() -> Union[dict, Exception]:
         DecodeError: 'Wrong JWT structure'
     }
     try:
-        payload = jwt.decode(get_auth_token(), current_app.config['SECRET_KEY'])
+        payload = jwt.decode(
+            get_auth_token(), current_app.config['SECRET_KEY']
+        )
         assert tuple(payload) == ('key',)
         return payload
     except tuple(expected_errors) as error:

--- a/api/utils.py
+++ b/api/utils.py
@@ -9,7 +9,9 @@ from api.errors import InvalidArgumentError, AuthorizationError
 
 
 def get_auth_token() -> Union[str, Exception]:
-    """Parse the incoming request's Authorization header and Validate it."""
+    """
+    Parse and validate incoming request Authorization header.
+    """
     expected_errors = {
         KeyError: 'Authorization header is missing',
         AssertionError: 'Wrong authorization type'
@@ -24,8 +26,7 @@ def get_auth_token() -> Union[str, Exception]:
 
 def get_jwt() -> Union[dict, Exception]:
     """
-    Get Authorization payload and validate its signature
-    according the application's secret key .
+    Decode Authorization token. Extract and validate credentials.
     """
     expected_errors = {
         AssertionError: 'Wrong JWT payload structure',
@@ -37,7 +38,7 @@ def get_jwt() -> Union[dict, Exception]:
         payload = jwt.decode(
             get_auth_token(), current_app.config['SECRET_KEY']
         )
-        assert tuple(payload) == ('key',)
+        assert payload.get('key')
         return payload
     except tuple(expected_errors) as error:
         raise AuthorizationError(expected_errors[error.__class__])

--- a/config.py
+++ b/config.py
@@ -6,7 +6,7 @@ from version import VERSION
 class Config:
     VERSION = VERSION
 
-    SECRET_KEY = os.environ.get('SECRET_KEY', '')
+    SECRET_KEY = os.environ.get('SECRET_KEY', None)
 
     API_URL = 'https://api.securitytrails.com/v1/'
     UI_URL = 'https://securitytrails.com/'

--- a/tests/unit/api/test_enrich.py
+++ b/tests/unit/api/test_enrich.py
@@ -143,7 +143,7 @@ def test_enrich_call_with_unauthorized_creds_failure(
 
         assert response.status_code == HTTPStatus.OK
         assert response.json == authorization_errors_expected_payload(
-            'Invalid API key'
+            '{"message":"Invalid authentication credentials"}\n'
         )
 
 

--- a/tests/unit/api/test_enrich.py
+++ b/tests/unit/api/test_enrich.py
@@ -29,7 +29,7 @@ def test_enrich_call_with_authorization_header_failure(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'authorization_header_failure'
+        'Authorization header is missing'
     )
 
 
@@ -44,7 +44,7 @@ def test_enrich_call_with_wrong_authorization_type(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'wrong_authorization_type'
+        'Wrong authorization type'
     )
 
 
@@ -59,7 +59,7 @@ def test_enrich_call_with_wrong_jwt_structure(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'wrong_jwt_structure'
+        'Wrong JWT structure'
     )
 
 
@@ -74,7 +74,7 @@ def test_enrich_call_with_jwt_encoded_by_wrong_key(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'jwt_encoded_by_wrong_key'
+        'Failed to decode JWT with provided key'
     )
 
 
@@ -89,7 +89,7 @@ def test_enrich_call_with_wrong_jwt_payload_structure(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'wrong_jwt_payload_structure'
+        'Wrong JWT payload structure'
     )
 
 
@@ -104,7 +104,7 @@ def test_enrich_call_with_missed_secret_key(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'missed_secret_key'
+        '<SECRET_KEY> is missing'
     )
 
 
@@ -143,7 +143,7 @@ def test_enrich_call_with_unauthorized_creds_failure(
 
         assert response.status_code == HTTPStatus.OK
         assert response.json == authorization_errors_expected_payload(
-            'unauthorized_creds_failure'
+            'Invalid API key'
         )
 
 

--- a/tests/unit/api/test_enrich.py
+++ b/tests/unit/api/test_enrich.py
@@ -21,15 +21,91 @@ IP_OBSERVABLE = {'type': 'ip', 'value': '1.1.1.1'}
 DOMAIN_OBSERVABLE = {'type': 'domain', 'value': 'cisco.com'}
 
 
-def test_enrich_call_with_invalid_jwt_failure(
-        route, client, invalid_jwt, invalid_jwt_expected_payload, valid_json
+def test_enrich_call_with_authorization_header_failure(
+        route, client, valid_json,
+        authorization_errors_expected_payload
+):
+    response = client.post(route, json=valid_json)
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json == authorization_errors_expected_payload(
+        'authorization_header_failure'
+    )
+
+
+def test_enrich_call_with_wrong_authorization_type(
+        route, client, valid_jwt, valid_json,
+        authorization_errors_expected_payload
 ):
     response = client.post(
-        route, headers=headers(invalid_jwt), json=valid_json
+        route, json=valid_json,
+        headers=headers(valid_jwt, auth_type='wrong_type')
     )
 
     assert response.status_code == HTTPStatus.OK
-    assert response.json == invalid_jwt_expected_payload
+    assert response.json == authorization_errors_expected_payload(
+        'wrong_authorization_type'
+    )
+
+
+def test_enrich_call_with_wrong_jwt_structure(
+        route, client, wrong_jwt_structure, valid_json,
+        authorization_errors_expected_payload
+):
+    response = client.post(
+        route, json=valid_json,
+        headers=headers(wrong_jwt_structure)
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json == authorization_errors_expected_payload(
+        'wrong_jwt_structure'
+    )
+
+
+def test_enrich_call_with_jwt_encoded_by_wrong_key(
+        route, client, invalid_jwt, valid_json,
+        authorization_errors_expected_payload
+):
+    response = client.post(
+        route, json=valid_json,
+        headers=headers(invalid_jwt)
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json == authorization_errors_expected_payload(
+        'jwt_encoded_by_wrong_key'
+    )
+
+
+def test_enrich_call_with_wrong_jwt_payload_structure(
+        route, client, wrong_payload_structure_jwt, valid_json,
+        authorization_errors_expected_payload
+):
+    response = client.post(
+        route, json=valid_json,
+        headers=headers(wrong_payload_structure_jwt)
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json == authorization_errors_expected_payload(
+        'wrong_jwt_payload_structure'
+    )
+
+
+def test_enrich_call_with_missed_secret_key(
+        route, client, valid_jwt, valid_json,
+        authorization_errors_expected_payload
+):
+    right_secret_key = client.application.secret_key
+    client.application.secret_key = None
+    response = client.post(route, json=valid_json, headers=headers(valid_jwt))
+    client.application.secret_key = right_secret_key
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json == authorization_errors_expected_payload(
+        'missed_secret_key'
+    )
 
 
 @fixture(scope='module')
@@ -57,7 +133,7 @@ def valid_json():
 def test_enrich_call_with_unauthorized_creds_failure(
         route, client, valid_jwt,
         securitytrails_response_unauthorized_creds,
-        unauthorized_creds_expected_payload, valid_json
+        authorization_errors_expected_payload, valid_json
 ):
     with patch('requests.request') as get_mock:
         get_mock.return_value = securitytrails_response_unauthorized_creds
@@ -66,7 +142,9 @@ def test_enrich_call_with_unauthorized_creds_failure(
         )
 
         assert response.status_code == HTTPStatus.OK
-        assert response.json == unauthorized_creds_expected_payload
+        assert response.json == authorization_errors_expected_payload(
+            'unauthorized_creds_failure'
+        )
 
 
 def observables():
@@ -112,7 +190,8 @@ def test_enrich_success_with_bad_request(
         get_mock.return_value = securitytrails_response_bad_request
 
         response = client.post(
-            '/observe/observables', headers=headers(valid_jwt), json=valid_json
+            '/observe/observables', headers=headers(valid_jwt),
+            json=valid_json
         )
 
         assert response.status_code == HTTPStatus.OK
@@ -158,7 +237,8 @@ def test_enrich_call_with_key_error(
         extract_mock.side_effect = [KeyError('foo')]
 
         response = client.post(
-            '/observe/observables', headers=headers(valid_jwt), json=valid_json
+            '/observe/observables', headers=headers(valid_jwt),
+            json=valid_json
         )
 
         assert response.status_code == HTTPStatus.OK

--- a/tests/unit/api/test_enrich.py
+++ b/tests/unit/api/test_enrich.py
@@ -143,7 +143,7 @@ def test_enrich_call_with_unauthorized_creds_failure(
 
         assert response.status_code == HTTPStatus.OK
         assert response.json == authorization_errors_expected_payload(
-            '{"message":"Invalid authentication credentials"}\n'
+            'Invalid authentication credentials'
         )
 
 

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -107,7 +107,7 @@ def test_health_call_with_unauthorized_creds_failure(
 
         assert response.status_code == HTTPStatus.OK
         assert response.json == authorization_errors_expected_payload(
-            '{"message":"Invalid authentication credentials"}\n'
+            'Invalid authentication credentials'
         )
 
 

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -107,7 +107,7 @@ def test_health_call_with_unauthorized_creds_failure(
 
         assert response.status_code == HTTPStatus.OK
         assert response.json == authorization_errors_expected_payload(
-            'Invalid API key'
+            '{"message":"Invalid authentication credentials"}\n'
         )
 
 

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -24,7 +24,7 @@ def test_health_call_with_authorization_header_failure(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'authorization_header_failure'
+        'Authorization header is missing'
     )
 
 
@@ -38,7 +38,7 @@ def test_health_call_with_wrong_authorization_type(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'wrong_authorization_type'
+        'Wrong authorization type'
     )
 
 
@@ -50,7 +50,7 @@ def test_health_call_with_wrong_jwt_structure(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'wrong_jwt_structure'
+        'Wrong JWT structure'
     )
 
 
@@ -62,7 +62,7 @@ def test_health_call_with_jwt_encoded_by_wrong_key(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'jwt_encoded_by_wrong_key'
+        'Failed to decode JWT with provided key'
     )
 
 
@@ -75,7 +75,7 @@ def test_health_call_with_wrong_jwt_payload_structure(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'wrong_jwt_payload_structure'
+        'Wrong JWT payload structure'
     )
 
 
@@ -90,7 +90,7 @@ def test_health_call_with_missed_secret_key(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'missed_secret_key'
+        '<SECRET_KEY> is missing'
     )
 
 
@@ -107,7 +107,7 @@ def test_health_call_with_unauthorized_creds_failure(
 
         assert response.status_code == HTTPStatus.OK
         assert response.json == authorization_errors_expected_payload(
-            'unauthorized_creds_failure'
+            'Invalid API key'
         )
 
 

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -16,28 +16,88 @@ def route(request):
     return request.param
 
 
-def test_health_call_without_jwt_failure(
-        route, client, invalid_jwt_expected_payload
+def test_health_call_with_authorization_header_failure(
+        route, client,
+        authorization_errors_expected_payload
 ):
     response = client.post(route)
 
     assert response.status_code == HTTPStatus.OK
-    assert response.json == invalid_jwt_expected_payload
+    assert response.json == authorization_errors_expected_payload(
+        'authorization_header_failure'
+    )
 
 
-def test_health_call_with_invalid_jwt_failure(
-        route, client, invalid_jwt, invalid_jwt_expected_payload
+def test_health_call_with_wrong_authorization_type(
+        route, client, valid_jwt,
+        authorization_errors_expected_payload
+):
+    response = client.post(
+        route, headers=headers(valid_jwt, auth_type='wrong_type')
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json == authorization_errors_expected_payload(
+        'wrong_authorization_type'
+    )
+
+
+def test_health_call_with_wrong_jwt_structure(
+        route, client, wrong_jwt_structure,
+        authorization_errors_expected_payload
+):
+    response = client.post(route, headers=headers(wrong_jwt_structure))
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json == authorization_errors_expected_payload(
+        'wrong_jwt_structure'
+    )
+
+
+def test_health_call_with_jwt_encoded_by_wrong_key(
+        route, client, invalid_jwt,
+        authorization_errors_expected_payload
 ):
     response = client.post(route, headers=headers(invalid_jwt))
 
     assert response.status_code == HTTPStatus.OK
-    assert response.json == invalid_jwt_expected_payload
+    assert response.json == authorization_errors_expected_payload(
+        'jwt_encoded_by_wrong_key'
+    )
+
+
+def test_health_call_with_wrong_jwt_payload_structure(
+        route, client, wrong_payload_structure_jwt,
+        authorization_errors_expected_payload
+):
+    response = client.post(route,
+                           headers=headers(wrong_payload_structure_jwt))
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json == authorization_errors_expected_payload(
+        'wrong_jwt_payload_structure'
+    )
+
+
+def test_health_call_with_missed_secret_key(
+        route, client, valid_jwt,
+        authorization_errors_expected_payload
+):
+    right_secret_key = client.application.secret_key
+    client.application.secret_key = None
+    response = client.post(route, headers=headers(valid_jwt))
+    client.application.secret_key = right_secret_key
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json == authorization_errors_expected_payload(
+        'missed_secret_key'
+    )
 
 
 def test_health_call_with_unauthorized_creds_failure(
         route, client, valid_jwt,
         securitytrails_response_unauthorized_creds,
-        unauthorized_creds_expected_payload,
+        authorization_errors_expected_payload
 ):
     with patch('requests.request') as get_mock:
         get_mock.return_value = securitytrails_response_unauthorized_creds
@@ -46,7 +106,9 @@ def test_health_call_with_unauthorized_creds_failure(
         )
 
         assert response.status_code == HTTPStatus.OK
-        assert response.json == unauthorized_creds_expected_payload
+        assert response.json == authorization_errors_expected_payload(
+            'unauthorized_creds_failure'
+        )
 
 
 def test_health_call_with_ssl_error_failure(

--- a/tests/unit/api/utils.py
+++ b/tests/unit/api/utils.py
@@ -1,2 +1,2 @@
-def headers(jwt):
-    return {'Authorization': f'Bearer {jwt}'}
+def headers(jwt, auth_type='Bearer'):
+    return {'Authorization': f'{auth_type} {jwt}'}

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -91,13 +91,14 @@ def securitytrails_api_response_mock(status_code, payload=None):
     return mock_response
 
 
-def securitytrails_api_error_mock(status_code, text=None):
+def securitytrails_api_error_mock(status_code, text=None, json=None):
     mock_response = MagicMock()
 
     mock_response.status_code = status_code
     mock_response.ok = status_code == HTTPStatus.OK
 
     mock_response.text = text
+    mock_response.json.return_value = json
 
     return mock_response
 
@@ -198,7 +199,8 @@ def securitytrails_domain_list_ok():
 def securitytrails_response_unauthorized_creds(secret_key):
     return securitytrails_api_error_mock(
         status_code=HTTPStatus.FORBIDDEN,
-        text='{"message":"Invalid authentication credentials"}\n'
+        text='{"message":"Invalid authentication credentials"}\n',
+        json={"message": "Invalid authentication credentials"}
     )
 
 
@@ -266,7 +268,7 @@ def unauthorized_creds_body():
                 'code': AUTH_ERROR,
                 'message':
                     'Authorization failed: '
-                    '{"message":"Invalid authentication credentials"}\n',
+                    'Invalid authentication credentials',
                 'type': 'fatal'}
         ],
         'data': {}

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -264,7 +264,9 @@ def unauthorized_creds_body():
         'errors': [
             {
                 'code': AUTH_ERROR,
-                'message': "Authorization failed: Invalid API key",
+                'message':
+                    'Authorization failed: '
+                    '{"message":"Invalid authentication credentials"}\n',
                 'type': 'fatal'}
         ],
         'data': {}

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -52,7 +52,6 @@ def wrong_payload_structure_jwt(client):
     return jwt.encode(header, payload, secret_key).decode('ascii')
 
 
-
 @fixture(scope='session')
 def invalid_jwt(valid_jwt):
     header, payload, signature = valid_jwt.split('.')

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -223,17 +223,7 @@ def expected_payload(r, observe_body, refer_body=None):
 @fixture(scope='module')
 def authorization_errors_expected_payload(route,
                                           success_enrich_refer_domain_body):
-    def _make_payload_message(test_name):
-        messages = {
-            'authorization_header_failure': 'Authorization header is missing',
-            'wrong_authorization_type': 'Wrong authorization type',
-            'wrong_jwt_structure': 'Wrong JWT structure',
-            'jwt_encoded_by_wrong_key':
-                'Failed to decode JWT with provided key',
-            'wrong_jwt_payload_structure': 'Wrong JWT payload structure',
-            'missed_secret_key': '<SECRET_KEY> is missing',
-            'unauthorized_creds_failure': 'Invalid API key'
-        }
+    def _make_payload_message(message):
         return expected_payload(
             route,
             {
@@ -241,7 +231,7 @@ def authorization_errors_expected_payload(route,
                     {
                         'code': AUTH_ERROR,
                         'message': f'Authorization failed: '
-                                   f'{messages[test_name]}',
+                                   f'{message}',
                         'type': 'fatal'}
                 ],
                 'data': {}


### PR DESCRIPTION
        removed: InvalidJWTError;
utils.py - add: get_auth_token(),
       changed: get_jwt(),
                get_key();
client.py - changing in _request();
test_health.py - add: test_health_call_with_authorization_header_failure(),
                      test_health_call_with_wrong_authorization_type(),
                      test_health_call_with_wrong_jwt_structure(),
                      test_health_call_with_jwt_encoded_by_wrong_key(),
                      test_health_call_with_wrong_jwt_payload_structure(),
                      test_health_call_with_missed_secret_key();
             changed: test_health_call_with_unauthorized_creds_failure();
             removed: test_health_call_without_jwt_failure(),
                      test_health_call_with_invalid_jwt_failure();
test_enrich.py - add: test_enrich_call_with_authorization_header_failure(),
                      test_enrich_call_with_wrong_authorization_type(),
                      test_enrich_call_with_wrong_jwt_structure(),
                      test_enrich_call_with_jwt_encoded_by_wrong_key(),
                      test_enrich_call_with_wrong_jwt_payload_structure(),
                      test_enrich_call_with_missed_secret_key();
             changed: test_enrich_call_with_unauthorized_creds_failure();
             removed: test_enrich_call_with_invalid_jwt_failure();
conftest.py - add: wrong_payload_structure_jwt(),
                   wrong_jwt_structure(),
                   authorization_errors_expected_payload();
          changed: valid_jwt(),
                   securitytrails_response_unauthorized_creds(),
                   unauthorized_creds_body();
          removed: invalid_jwt_expected_payload(),
                   unauthorized_creds_expected_payload();
little fix: config.py - SECRET_KEY
            tests/units/api/utils.py - headers()